### PR TITLE
Master database manager - Added watched episode backend support

### DIFF
--- a/PlotTalk/Src/common.h
+++ b/PlotTalk/Src/common.h
@@ -4,6 +4,8 @@
  */
 #ifndef COMMON_H
 #define COMMON_H
+#include <QString>
+#include <QList>
 
 /**
  * @brief The EpisodeIdentifier struct, identifies a specific episode in the datastore.
@@ -13,6 +15,37 @@ struct EpisodeIdentifier
     int tvShowId;
     int seasonId;
     int episodeId;
+
+    bool operator==(const EpisodeIdentifier &rhs) const
+    {
+        return ( (tvShowId == rhs.tvShowId) && (seasonId == rhs.seasonId) && (episodeId == rhs.episodeId) );
+    }
+
+    // Returns the tvShowId, seasonId, episodeId concatented, with : as the delimiter.
+    // This is intended to be used as the key for a dictionary.
+    QString getKey() const
+    {
+        return QString::number(tvShowId) + ":" + QString::number(seasonId) + ":" + QString::number(episodeId);
+    }
+
+    // Used for sorting
+    bool operator<(const EpisodeIdentifier &rhs) const
+    {
+        return (this->getKey() < rhs.getKey());
+    }
+
+    // Converts an EpisodeIdentifier key into an EpisodeIdentifier.
+    static EpisodeIdentifier fromKey(const QString &episodeIdentifierKey)
+    {
+        QList<QString> keyItems = episodeIdentifierKey.split(":");
+        EpisodeIdentifier episodeIdentifier;
+        episodeIdentifier.tvShowId = keyItems[0].toInt();
+        episodeIdentifier.seasonId = keyItems[1].toInt();
+        episodeIdentifier.episodeId = keyItems[2].toInt();
+
+        return episodeIdentifier;
+    }
+
 };
 
 #endif // COMMON_H

--- a/PlotTalk/Src/databasemanager.cpp
+++ b/PlotTalk/Src/databasemanager.cpp
@@ -275,6 +275,30 @@ void DatabaseManager::addEpisodeComment(EpisodeIdentifier episodeIdentifier, Com
 }
 
 /**
+ * @brief DatabaseManager::addWatchedEpisode Adds the specified episode to the specified users watched episodes list.
+ * @param episodeIdentifier The episode to add to the users watched shows.
+ * @param username The username to add the watched episode to.
+ */
+void DatabaseManager::addWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username)
+{
+    userMap[username].addWatchedEpisode(episodeIdentifier);
+    connection.addWatchedEpisode(episodeIdentifier, username);
+    emit notify();
+}
+
+/**
+ * @brief DatabaseManager::removeWatchedEpisode Removes the specified episode from the specified users watched episodes list.
+ * @param episodeIdentifier The episode to remove from the users watched shows.
+ * @param username The username to remove the watched episode from.
+ */
+void DatabaseManager::removeWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username)
+{
+    userMap[username].removeWatchedEpisode(episodeIdentifier);
+    connection.removeWatchedEpisode(episodeIdentifier, username);
+    emit notify();
+}
+
+/**
  * @brief DatabaseManager::emptyCache Used for testing only, to empty cache.
  */
 void DatabaseManager::emptyCache()

--- a/PlotTalk/Src/databasemanager.cpp
+++ b/PlotTalk/Src/databasemanager.cpp
@@ -299,6 +299,25 @@ void DatabaseManager::removeWatchedEpisode(EpisodeIdentifier episodeIdentifier, 
 }
 
 /**
+ * @brief DatabaseManager::getListOfWatchedTvShowNamesForUser Returns a list of tvshow names for the tvshows the specified username has watched.
+ * @param username The username to lookup.
+ * @return List of tvshow names that have been watched by the specified user.
+ */
+QList<QString> DatabaseManager::getListOfWatchedTvShowNamesForUser(QString username)
+{
+    QList<QString> watchedTvShowNames;
+
+    User user = inspectUser(username);
+
+    foreach(const EpisodeIdentifier &episodeIdentifier, user.inspectWatchedEpisodes())
+    {
+        watchedTvShowNames.append(getTvShowNameById(episodeIdentifier.tvShowId));
+    }
+
+    return watchedTvShowNames;
+}
+
+/**
  * @brief DatabaseManager::emptyCache Used for testing only, to empty cache.
  */
 void DatabaseManager::emptyCache()

--- a/PlotTalk/Src/databasemanager.h
+++ b/PlotTalk/Src/databasemanager.h
@@ -68,7 +68,7 @@ public:
 
     void removeWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username);
 
-    //@todo Add get list of watched tvshows, once watched functionality is added.
+    QList<QString> getListOfWatchedTvShowNamesForUser(QString username);
 
     // Used for testing only.
     void emptyCache();

--- a/PlotTalk/Src/databasemanager.h
+++ b/PlotTalk/Src/databasemanager.h
@@ -64,6 +64,10 @@ public:
     // @throws NotFound
     void addEpisodeComment(EpisodeIdentifier episodeIdentifier, Comment comment);
 
+    void addWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username);
+
+    void removeWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username);
+
     //@todo Add get list of watched tvshows, once watched functionality is added.
 
     // Used for testing only.

--- a/PlotTalk/Src/iconnection.h
+++ b/PlotTalk/Src/iconnection.h
@@ -66,6 +66,11 @@ public:
     virtual void addEpisodeReview(EpisodeIdentifier episodeIdentifier, Review review) = 0;
 
     virtual void addEpisodeComment(EpisodeIdentifier episodeIdentifier, Comment comment) = 0;
+
+    virtual void addWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username) = 0;
+
+    virtual void removeWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username) = 0;
+
 };
 
 #endif // ICONNECTION_H

--- a/PlotTalk/Src/jsonconnection.cpp
+++ b/PlotTalk/Src/jsonconnection.cpp
@@ -631,7 +631,7 @@ QJsonObject JsonConnection::userToJsonObject(User user)
     jsonObject.insert("email", QJsonValue(user.email));
     jsonObject.insert("passwordHash", QJsonValue(user.passwordHash));
     jsonObject.insert("_isAdmin", QJsonValue(user.isAdmin()));
-    jsonObject.insert("watchedEpisodes", watchedEpisodesToJsonArray(user.watchedEpisodes));
+    jsonObject.insert("watchedEpisodes", watchedEpisodesToJsonArray(user.inspectWatchedEpisodes()));
 
     return jsonObject;
 }

--- a/PlotTalk/Src/jsonconnection.cpp
+++ b/PlotTalk/Src/jsonconnection.cpp
@@ -866,6 +866,90 @@ void JsonConnection::addEpisodeComment(EpisodeIdentifier episodeIdentifier, Comm
 }
 
 /**
+ * @brief JsonConnection::addWatchedEpisode Adds the specified episode to the specified users watched list.
+ * @param episodeIdentifier The episode that was watched.
+ * @param username The username that watched the episode.
+ *
+ * @throws NotFound
+ */
+void JsonConnection::addWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username)
+{
+    QJsonArray users = getTopLevelJsonArray(JSON_USER_ARRAY_NAME);
+    User user;
+
+    QJsonObject obj;
+
+    int index = 0;
+    bool found = false;
+    foreach (const QJsonValue &value, users)
+    {
+        obj = value.toObject();
+        if ( obj["username"] ==  username )
+        {
+            user = getUser(obj["username"].toString());
+            found = true;
+            break;
+        }
+
+        ++index;
+    }
+
+    if ( ! found )
+    {
+        throw NotFound("User not found:" + username);
+    }
+
+    user.addWatchedEpisode(episodeIdentifier);
+
+    users.replace(index, userToJsonObject(user));
+
+    json[JSON_USER_ARRAY_NAME] = users;
+
+    saveJson();
+}
+
+/**
+ * @brief JsonConnection::removeWatchedEpisode Removes the specified episode from the specified users watched list.
+ * @param episodeIdentifier The episode that was not watched.
+ * @param username The username to remove the watched episode from.
+ */
+void JsonConnection::removeWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username)
+{
+    QJsonArray users = getTopLevelJsonArray(JSON_USER_ARRAY_NAME);
+    User user;
+
+    QJsonObject obj;
+
+    int index = 0;
+    bool found = false;
+    foreach (const QJsonValue &value, users)
+    {
+        obj = value.toObject();
+        if ( obj["username"] ==  username )
+        {
+            user = getUser(obj["username"].toString());
+            found = true;
+            break;
+        }
+
+        ++index;
+    }
+
+    if ( ! found )
+    {
+        throw NotFound("User not found:" + username);
+    }
+
+    user.removeWatchedEpisode(episodeIdentifier);
+
+    users.replace(index, userToJsonObject(user));
+
+    json[JSON_USER_ARRAY_NAME] = users;
+
+    saveJson();
+}
+
+/**
  * @brief JsonConnection::loadJson Reads the specified json from file.
   */
 void JsonConnection::loadJson()

--- a/PlotTalk/Src/jsonconnection.h
+++ b/PlotTalk/Src/jsonconnection.h
@@ -56,6 +56,9 @@ public:
     void addEpisodeReview(EpisodeIdentifier episodeIdentifier, Review review);
     void addEpisodeComment(EpisodeIdentifier episodeIdentifier, Comment comment);
 
+    void addWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username);
+    void removeWatchedEpisode(EpisodeIdentifier episodeIdentifier, QString username);
+
     // Normally the loadJson and saveJson wouldn't be public, but they have been made public,
     // for easy access by QTest. TODO: Investigate alternative access. ex. Via Friendly classes.
     void loadJson();

--- a/PlotTalk/Src/jsonconnection.h
+++ b/PlotTalk/Src/jsonconnection.h
@@ -10,6 +10,7 @@
 #include "user.h"
 
 #include <QString>
+#include <QList>
 #include <QJsonObject>
 #include <QJsonValue>
 
@@ -90,6 +91,8 @@ private:
     QJsonValue commentToJsonValue(Comment comment);
 
     QJsonObject userToJsonObject(User user);
+    QJsonArray watchedEpisodesToJsonArray(QList<EpisodeIdentifier> watchedEpisodes);
+    QList<EpisodeIdentifier> getWatchedEpisodes(QJsonArray jsonWatchedEpisodes);
 };
 
 #endif // JSONCONNECTION_H

--- a/PlotTalk/Src/user.cpp
+++ b/PlotTalk/Src/user.cpp
@@ -139,9 +139,6 @@ void User::removeWatchedEpisodeList(QList<EpisodeIdentifier> episodeList)
     }
 }
 
-
-
-
 QList<EpisodeIdentifier> User::inspectWatchedEpisodes()
 {
     return watchedEpisodes.values();

--- a/PlotTalk/Src/user.cpp
+++ b/PlotTalk/Src/user.cpp
@@ -15,7 +15,7 @@ User::User()
     email = "";
     passwordHash = "";
     _isAdmin = false;
-    userWatched = QList<EpisodeIdentifier>();
+    watchedEpisodes = QList<EpisodeIdentifier>();
 }
 
 User::User(QString username, QString firstName, QString lastName, QString email, QString passwordhash)
@@ -26,32 +26,44 @@ User::User(QString username, QString firstName, QString lastName, QString email,
     this->email = email;
     this->passwordHash = passwordhash;
     _isAdmin = false;
-    userWatched = QList<EpisodeIdentifier>();
+    watchedEpisodes = QList<EpisodeIdentifier>();
+}
+
+User::User(QString username, QString firstName, QString lastName, QString email, QString passwordHash, QList<EpisodeIdentifier> watchedEpisodes)
+{
+    this->username = username;
+    this->firstName = firstName;
+    this->lastName = lastName;
+    this->email = email;
+    this->passwordHash = passwordHash;
+    addWatchedEpisodeList(watchedEpisodes);
+
+    _isAdmin = false;
 }
 
 
-User::User(QString username, QString firstName, QString lastName, QString email, QString passwordhash, bool isAdmin)
+User::User(QString username, QString firstName, QString lastName, QString email, QString passwordHash, bool isAdmin)
+{
+    this->username = username;
+    this->firstName = firstName;
+    this->lastName = lastName;
+    this->email = email;
+    this->passwordHash = passwordHash;
+    watchedEpisodes = QList<EpisodeIdentifier>();
+
+    _isAdmin = isAdmin;
+}
+
+User::User(QString username, QString firstName, QString lastName, QString email, QString passwordhash, QList<EpisodeIdentifier> watchedEpisodes, bool isAdmin)
 {
     this->username = username;
     this->firstName = firstName;
     this->lastName = lastName;
     this->email = email;
     this->passwordHash = passwordhash;
+    addWatchedEpisodeList(watchedEpisodes);
+
     _isAdmin = isAdmin;
-    userWatched = QList<EpisodeIdentifier>();
-}
-
-User::User(QString username, QString firstName, QString lastName, QString email, QString passwordhash, bool isAdmin, QList<EpisodeIdentifier> episodeList)
-{
-    this->username = username;
-    this->firstName = firstName;
-    this->lastName = lastName;
-    this->email = email;
-    this->passwordHash = passwordhash;
-    _isAdmin = isAdmin;
-
-    addWatchedEpisodeList(episodeList);
-
 }
 
 bool User::isAdmin()
@@ -68,7 +80,7 @@ bool User::addWatchedEpisode(EpisodeIdentifier episode)//adds an episode to the 
     }
     else
     {
-        userWatched.append(episode);
+        watchedEpisodes.append(episode);
         return true;
     }
 
@@ -82,7 +94,7 @@ bool User::removeWatchedEpisode(EpisodeIdentifier episode)//removes an episode f
 
         if(hasUserWatchedThisEpisode(episode,location))
         {
-            userWatched.removeAt(location);
+            watchedEpisodes.removeAt(location);
             return true;
         }
         else
@@ -98,11 +110,11 @@ bool User::hasUserWatchedThisEpisode(EpisodeIdentifier episode, int &location)//
     if(hasTheUserWatchedAnything())
     {
         int i;
-        for(i=0; i < userWatched.size(); i++)
+        for(i=0; i < watchedEpisodes.size(); i++)
         {
-            if(userWatched[i].episodeId == episode.episodeId &&
-               userWatched[i].seasonId == episode.seasonId &&
-               userWatched[i].tvShowId == episode.tvShowId)
+            if(watchedEpisodes[i].episodeId == episode.episodeId &&
+               watchedEpisodes[i].seasonId == episode.seasonId &&
+               watchedEpisodes[i].tvShowId == episode.tvShowId)
             {
                 location=i;
                 return true;
@@ -114,7 +126,7 @@ bool User::hasUserWatchedThisEpisode(EpisodeIdentifier episode, int &location)//
 
 bool User::hasTheUserWatchedAnything()
 {
-    if(userWatched.size()==0)
+    if(watchedEpisodes.size()==0)
         return false;
     else
         return true;

--- a/PlotTalk/Src/user.cpp
+++ b/PlotTalk/Src/user.cpp
@@ -15,7 +15,7 @@ User::User()
     email = "";
     passwordHash = "";
     _isAdmin = false;
-    watchedEpisodes = QList<EpisodeIdentifier>();
+    watchedEpisodes = QMap<QString, EpisodeIdentifier>();
 }
 
 User::User(QString username, QString firstName, QString lastName, QString email, QString passwordhash)
@@ -26,7 +26,7 @@ User::User(QString username, QString firstName, QString lastName, QString email,
     this->email = email;
     this->passwordHash = passwordhash;
     _isAdmin = false;
-    watchedEpisodes = QList<EpisodeIdentifier>();
+    watchedEpisodes = QMap<QString, EpisodeIdentifier>();
 }
 
 User::User(QString username, QString firstName, QString lastName, QString email, QString passwordHash, QList<EpisodeIdentifier> watchedEpisodes)
@@ -49,7 +49,7 @@ User::User(QString username, QString firstName, QString lastName, QString email,
     this->lastName = lastName;
     this->email = email;
     this->passwordHash = passwordHash;
-    watchedEpisodes = QList<EpisodeIdentifier>();
+    watchedEpisodes = QMap<QString, EpisodeIdentifier>();
 
     _isAdmin = isAdmin;
 }
@@ -71,89 +71,78 @@ bool User::isAdmin()
     return _isAdmin;
 }
 
-bool User::addWatchedEpisode(EpisodeIdentifier episode)//adds an episode to the users watched list
+/**
+ * @brief User::addWatchedEpisode Adds a watched episode, no error if it was already marked as watched.
+ * @param episode The episode identifier for the watched episode.
+ */
+void User::addWatchedEpisode(EpisodeIdentifier episode)//adds an episode to the users watched list
 {
-    int dummy;
-    if(hasUserWatchedThisEpisode(episode, dummy))
-    {
-        return false;
-    }
-    else
-    {
-        watchedEpisodes.append(episode);
-        return true;
-    }
-
+    watchedEpisodes.insert(episode.getKey(), episode);
 }
 
-bool User::removeWatchedEpisode(EpisodeIdentifier episode)//removes an episode from the users watched list
+/**
+ * @brief User::removeWatchedEpisode Removes watched episode, no error if episode was not marked as watched.
+ * @param episode The episode to remove from watched episodes.
+ */
+void User::removeWatchedEpisode(EpisodeIdentifier episode)//removes an episode from the users watched list
 {
-    if(hasTheUserWatchedAnything())
-    {
-        int location;
-
-        if(hasUserWatchedThisEpisode(episode,location))
-        {
-            watchedEpisodes.removeAt(location);
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-    }
-        return false;
+    watchedEpisodes.remove(episode.getKey());
 }
 
-bool User::hasUserWatchedThisEpisode(EpisodeIdentifier episode, int &location)//private, checks to see if an episode is in the users watched list
+/**
+ * @brief User::hasUserWatchedThisEpisode Determines if the user has watched the specified episode.
+ * @param episode The episode to check if they have watched.
+ * @return True if the episode was watched by this user, false if not.
+ */
+bool User::hasUserWatchedThisEpisode(EpisodeIdentifier episode)
 {
-    if(hasTheUserWatchedAnything())
-    {
-        int i;
-        for(i=0; i < watchedEpisodes.size(); i++)
-        {
-            if(watchedEpisodes[i].episodeId == episode.episodeId &&
-               watchedEpisodes[i].seasonId == episode.seasonId &&
-               watchedEpisodes[i].tvShowId == episode.tvShowId)
-            {
-                location=i;
-                return true;
-            }
-        }
-    }
-    return false;
+    return watchedEpisodes.contains(episode.getKey());
 }
 
+/**
+ * @brief User::hasTheUserWatchedAnything Checks if the user has watched any episodes.
+ * @return True, if the user has watched at least one thing, false if not.
+ */
 bool User::hasTheUserWatchedAnything()
 {
-    if(watchedEpisodes.size()==0)
+    if(watchedEpisodes.size() == 0)
+    {
         return false;
+    }
     else
+    {
         return true;
+    }
+}
+
+/**
+ * @brief User::addWatchedEpisodeList Adds the provided episode list to the watched episodes. No error if already marked as watched.
+ * @param episodeList The list of episodes to mark as watched.
+ */
+void User::addWatchedEpisodeList(QList<EpisodeIdentifier> episodeList)
+{
+    foreach(const EpisodeIdentifier &episode, episodeList)
+    {
+        watchedEpisodes.insert(episode.getKey(), episode);
+    }
+}
+
+/**
+ * @brief User::removeWatchedEpisodeList Removes all episodes in the provided list. No error if episode is not marked as watched.
+ * @param episodeList The list of episodes to remove.
+ */
+void User::removeWatchedEpisodeList(QList<EpisodeIdentifier> episodeList)
+{
+    foreach(const EpisodeIdentifier &episode, episodeList)
+    {
+        watchedEpisodes.remove(episode.getKey());
+    }
 }
 
 
-bool User::addWatchedEpisodeList(QList<EpisodeIdentifier> episodeList)
+
+
+QList<EpisodeIdentifier> User::inspectWatchedEpisodes()
 {
-  if(episodeList.size()!=0)
-    {
-        int dummy=0;
-        for (int i=0; i<episodeList.size(); i++)
-        {
-          if(hasUserWatchedThisEpisode(episodeList[i], dummy))
-          {
-              return false;
-          }
-        }
-        for (int i=0; i<episodeList.size(); i++)
-        {
-          if(!addWatchedEpisode(episodeList[i]))
-          {
-              return false;
-          }
-        }
-        return true;
-    }
-    else
-        return false;
+    return watchedEpisodes.values();
 }

--- a/PlotTalk/Src/user.h
+++ b/PlotTalk/Src/user.h
@@ -18,13 +18,14 @@ public:
     QString lastName;
     QString email;
     QString passwordHash;
-    QList<EpisodeIdentifier> userWatched;
+    QList<EpisodeIdentifier> watchedEpisodes;
 
     // TODO: Complete creating User object.
     User();
     User(QString username, QString firstName, QString lastName, QString email, QString passwordHash);
     User(QString username, QString firstName, QString lastName, QString email, QString passwordHash, bool isAdmin);
-    User(QString username, QString firstName, QString lastName, QString email, QString passwordhash, bool isAdmin, QList<EpisodeIdentifier> episodeList);
+    User(QString username, QString firstName, QString lastName, QString email, QString passwordHash, QList<EpisodeIdentifier> watchedEpisodes);
+    User(QString username, QString firstName, QString lastName, QString email, QString passwordHash, QList<EpisodeIdentifier> watchedEpisodes, bool isAdmin);
 
     bool isAdmin();
     bool addWatchedEpisode(EpisodeIdentifier episode);

--- a/PlotTalk/Src/user.h
+++ b/PlotTalk/Src/user.h
@@ -8,6 +8,7 @@
 #include "common.h"
 #include <QString>
 #include <QList>
+#include <QMap>
 
 class User
 {
@@ -18,7 +19,6 @@ public:
     QString lastName;
     QString email;
     QString passwordHash;
-    QList<EpisodeIdentifier> watchedEpisodes;
 
     // TODO: Complete creating User object.
     User();
@@ -28,12 +28,17 @@ public:
     User(QString username, QString firstName, QString lastName, QString email, QString passwordHash, QList<EpisodeIdentifier> watchedEpisodes, bool isAdmin);
 
     bool isAdmin();
-    bool addWatchedEpisode(EpisodeIdentifier episode);
-    bool removeWatchedEpisode(EpisodeIdentifier episode);
+
+    void addWatchedEpisode(EpisodeIdentifier episode);
+    void removeWatchedEpisode(EpisodeIdentifier episode);
+    bool hasUserWatchedThisEpisode(EpisodeIdentifier episode);
+    void addWatchedEpisodeList(QList<EpisodeIdentifier> episodeList);
+    void removeWatchedEpisodeList(QList<EpisodeIdentifier> episodeList);
+
     bool hasTheUserWatchedAnything();
-    bool hasUserWatchedThisEpisode(EpisodeIdentifier episode, int &location);
-    bool addWatchedEpisodeList(QList<EpisodeIdentifier> episodeList);
+    QList<EpisodeIdentifier> inspectWatchedEpisodes();
 private:
+    QMap<QString, EpisodeIdentifier> watchedEpisodes;
     bool _isAdmin;
 
 

--- a/PlotTalk/Test/testdatabasemanager.cpp
+++ b/PlotTalk/Test/testdatabasemanager.cpp
@@ -5,6 +5,7 @@
 #include <QtTest/QtTest>
 #include "plottalkexceptions.h"
 #include "testdatabasemanager.h"
+#include "common.h"
 
 /**
  * @brief TestDatabaseManager::TestGetTvShowDefaultConstructor Uses the default constructor for the DBManager and looks up
@@ -135,12 +136,17 @@ void TestDatabaseManager::TestAddUser()
     QString expectedEmail = "nuser@gmail.com";
     QString expectedPasswordHash = "newuser123";
 
+    QList<EpisodeIdentifier> expectedWatchedEpisodes = QList<EpisodeIdentifier>();
+
+    expectedWatchedEpisodes.append(EpisodeIdentifier::fromKey("1:2:3"));
+    expectedWatchedEpisodes.append(EpisodeIdentifier::fromKey("4:5:6"));
+
     typedef Singleton<DatabaseManager> DatabaseManagerSingleton;
 
     qDebug() << "Removing user before attempting to add.";
     DatabaseManagerSingleton::Instance().removeUser(username);
 
-    User userBefore = User(username, expectedFirstName, expectedLastName, expectedEmail, expectedPasswordHash);
+    User userBefore = User(username, expectedFirstName, expectedLastName, expectedEmail, expectedPasswordHash, expectedWatchedEpisodes);
     DatabaseManagerSingleton::Instance().addUser(userBefore);
 
     User userAfter = DatabaseManagerSingleton::Instance().inspectUser(username);
@@ -150,6 +156,18 @@ void TestDatabaseManager::TestAddUser()
     QCOMPARE(userAfter.lastName, expectedLastName);
     QCOMPARE(userAfter.email, expectedEmail);
     QCOMPARE(userAfter.passwordHash, expectedPasswordHash);
+    QCOMPARE(userAfter.isAdmin(), false);
+
+    // Make sure both lists are the same length.
+    QCOMPARE(userAfter.watchedEpisodes.size(), expectedWatchedEpisodes.size());
+
+    qSort(expectedWatchedEpisodes);
+    qSort(userAfter.watchedEpisodes);
+
+    for (int i = 0; i < expectedWatchedEpisodes.size(); i++)
+    {
+        QCOMPARE(userAfter.watchedEpisodes[i].getKey(), expectedWatchedEpisodes[i].getKey());
+    }
 
     qDebug() << "Removing user after test.";
     DatabaseManagerSingleton::Instance().removeUser(username);

--- a/PlotTalk/Test/testdatabasemanager.cpp
+++ b/PlotTalk/Test/testdatabasemanager.cpp
@@ -576,3 +576,59 @@ bool TestDatabaseManager::deleteTempJson()
 
     return true;
 }
+
+void TestDatabaseManager::TestWatchedTvShowList()
+{
+    QString username = "newbsmith";
+    QString firstName = "Newb";
+    QString lastName = "Smith";
+    QString email = "newbsmith@gmail.com";
+    QString passwordHash = "badpasswordhash";
+
+    QList<QString> expectedWatchedShows = QList<QString>();
+
+    EpisodeIdentifier episode1;
+    episode1.episodeId=1;
+    episode1.seasonId=2;
+    episode1.tvShowId=62560; // Actual tvshow Id for Mr.Robot.
+
+    expectedWatchedShows.append("Mr. Robot");
+
+    EpisodeIdentifier episode2;
+    episode2.episodeId=2;
+    episode2.seasonId=3;
+    episode2.tvShowId=63926; // Actual tvshow Id for One-Punch Man.
+
+    expectedWatchedShows.append("One-Punch Man");
+
+    User user = User(username, firstName, lastName, email, passwordHash);
+
+    user.addWatchedEpisode(episode1);
+    user.addWatchedEpisode(episode2);
+
+    typedef Singleton<DatabaseManager> DatabaseManagerSingleton;
+
+    // Make sure user doesn't already exist before adding it.
+    DatabaseManagerSingleton::Instance().removeUser(user.username);
+
+    DatabaseManagerSingleton::Instance().addUser(user);
+
+    QList<QString> watchedShows = DatabaseManagerSingleton::Instance().getListOfWatchedTvShowNamesForUser(user.username);
+
+    // Make sure both lists are the same size.
+    QCOMPARE(watchedShows.size(), expectedWatchedShows.size());
+
+    qSort(expectedWatchedShows);
+    qSort(watchedShows);
+
+    for (int i = 0; i < expectedWatchedShows.size(); i++)
+    {
+        qDebug() << "Actual:" << watchedShows[i];
+        qDebug() << "Expected:" << expectedWatchedShows[i];
+        QCOMPARE(watchedShows[i], expectedWatchedShows[i]);
+    }
+
+    // Remove user when done.
+    DatabaseManagerSingleton::Instance().removeUser(user.username);
+}
+

--- a/PlotTalk/Test/testdatabasemanager.cpp
+++ b/PlotTalk/Test/testdatabasemanager.cpp
@@ -335,6 +335,15 @@ void TestDatabaseManager::TestGetAllUsers()
 
     QList<QString> allUsers = DatabaseManagerSingleton::Instance(":/json/Json/test.json").getListOfAllUsers();
 
+    User user;
+    foreach (const QString &username, allUsers)
+    {
+        user = DatabaseManagerSingleton::Instance().inspectUser(username);
+        qDebug() << "Expected:" << username;
+        qDebug() << "Actual:" << user.username;
+        QCOMPARE(user.username, username);
+    }
+
     QCOMPARE(allUsers.count(), 10);
 
     // @todo, add more validation.

--- a/PlotTalk/Test/testdatabasemanager.cpp
+++ b/PlotTalk/Test/testdatabasemanager.cpp
@@ -158,15 +158,17 @@ void TestDatabaseManager::TestAddUser()
     QCOMPARE(userAfter.passwordHash, expectedPasswordHash);
     QCOMPARE(userAfter.isAdmin(), false);
 
+    QList<EpisodeIdentifier> userAfterWatchedEpisodes = userAfter.inspectWatchedEpisodes();
+
     // Make sure both lists are the same length.
-    QCOMPARE(userAfter.watchedEpisodes.size(), expectedWatchedEpisodes.size());
+    QCOMPARE(userAfterWatchedEpisodes.size(), expectedWatchedEpisodes.size());
 
     qSort(expectedWatchedEpisodes);
-    qSort(userAfter.watchedEpisodes);
+    qSort(userAfterWatchedEpisodes);
 
     for (int i = 0; i < expectedWatchedEpisodes.size(); i++)
     {
-        QCOMPARE(userAfter.watchedEpisodes[i].getKey(), expectedWatchedEpisodes[i].getKey());
+        QCOMPARE(userAfterWatchedEpisodes[i].getKey(), expectedWatchedEpisodes[i].getKey());
     }
 
     qDebug() << "Removing user after test.";

--- a/PlotTalk/Test/testdatabasemanager.h
+++ b/PlotTalk/Test/testdatabasemanager.h
@@ -33,6 +33,7 @@ private slots:
     void TestGetTvShowById();
     void TestAddEpisodeReview();
     void TestAddEpisodeComment();
+    void TestAddAndRemoveWatchedEpisode();
 
 private:
     bool deleteTempJson();

--- a/PlotTalk/Test/testdatabasemanager.h
+++ b/PlotTalk/Test/testdatabasemanager.h
@@ -34,6 +34,7 @@ private slots:
     void TestAddEpisodeReview();
     void TestAddEpisodeComment();
     void TestAddAndRemoveWatchedEpisode();
+    void TestWatchedTvShowList();
 
 private:
     bool deleteTempJson();

--- a/PlotTalk/Test/testjsonconnection.cpp
+++ b/PlotTalk/Test/testjsonconnection.cpp
@@ -364,11 +364,11 @@ void TestJsonConnection::TestUserWatchedEpisodes()
     QCOMPARE(user.passwordHash, passwordHash);
     QCOMPARE(user.isAdmin(), false);
 
-    qSort(watchedEpisodes);
-    qSort(user.watchedEpisodes);
-
     // Make sure both lists are the same length.
     QCOMPARE(user.watchedEpisodes.size(), watchedEpisodes.size());
+
+    qSort(watchedEpisodes);
+    qSort(user.watchedEpisodes);
 
     for (int i = 0; i < watchedEpisodes.size(); i++)
     {

--- a/PlotTalk/Test/testjsonconnection.cpp
+++ b/PlotTalk/Test/testjsonconnection.cpp
@@ -364,15 +364,17 @@ void TestJsonConnection::TestUserWatchedEpisodes()
     QCOMPARE(user.passwordHash, passwordHash);
     QCOMPARE(user.isAdmin(), false);
 
+    QList<EpisodeIdentifier> userAfterWatchedEpisodes = user.inspectWatchedEpisodes();
+
     // Make sure both lists are the same length.
-    QCOMPARE(user.watchedEpisodes.size(), watchedEpisodes.size());
+    QCOMPARE(userAfterWatchedEpisodes.size(), watchedEpisodes.size());
 
     qSort(watchedEpisodes);
-    qSort(user.watchedEpisodes);
+    qSort(userAfterWatchedEpisodes);
 
     for (int i = 0; i < watchedEpisodes.size(); i++)
     {
-        QCOMPARE(user.watchedEpisodes[i].getKey(), watchedEpisodes[i].getKey());
+        QCOMPARE(userAfterWatchedEpisodes[i].getKey(), watchedEpisodes[i].getKey());
     }
 
     // Remove user when done.

--- a/PlotTalk/Test/testjsonconnection.cpp
+++ b/PlotTalk/Test/testjsonconnection.cpp
@@ -322,3 +322,59 @@ void TestJsonConnection::TestGetListOfAllTvShows()
     QCOMPARE(allTvShows[0],tvShow0);
     QCOMPARE(allTvShows[1],tvShow1);
 }
+
+void TestJsonConnection::TestUserWatchedEpisodes()
+{
+    // Set up strings to compare against.
+    QString username = "nuser";
+    QString firstName = "New";
+    QString lastName = "User";
+    QString email = "nuser@gmail.com";
+    QString passwordHash = "newuser123";
+    QList<EpisodeIdentifier> watchedEpisodes = QList<EpisodeIdentifier>();
+
+    EpisodeIdentifier eI1;
+    eI1.tvShowId = 1;
+    eI1.seasonId = 2;
+    eI1.episodeId = 3;
+
+    EpisodeIdentifier eI2;
+    eI2.tvShowId = 4;
+    eI2.seasonId = 5;
+    eI2.episodeId = 6;
+
+    watchedEpisodes.append(eI1);
+    watchedEpisodes.append(eI2);
+
+    JsonConnection jsonConnection = JsonConnection();
+
+    User user = User(username, firstName, lastName, email, passwordHash, watchedEpisodes);
+
+    // Remove user if it already exists.
+    jsonConnection.removeUser(username);
+
+    jsonConnection.addUser(user);
+
+    user = jsonConnection.getUser(username);
+
+    QCOMPARE(user.username, username);
+    QCOMPARE(user.firstName, firstName);
+    QCOMPARE(user.lastName, lastName);
+    QCOMPARE(user.email, email);
+    QCOMPARE(user.passwordHash, passwordHash);
+    QCOMPARE(user.isAdmin(), false);
+
+    qSort(watchedEpisodes);
+    qSort(user.watchedEpisodes);
+
+    // Make sure both lists are the same length.
+    QCOMPARE(user.watchedEpisodes.size(), watchedEpisodes.size());
+
+    for (int i = 0; i < watchedEpisodes.size(); i++)
+    {
+        QCOMPARE(user.watchedEpisodes[i].getKey(), watchedEpisodes[i].getKey());
+    }
+
+    // Remove user when done.
+    jsonConnection.removeUser(username);
+}

--- a/PlotTalk/Test/testjsonconnection.h
+++ b/PlotTalk/Test/testjsonconnection.h
@@ -26,6 +26,7 @@ private slots:
     void NegTestEmailExists();
     void TestSaveJson();
     void TestGetListOfAllTvShows();
+    void TestUserWatchedEpisodes();
     //void TestAddEpisodeReview();
 };
 

--- a/PlotTalk/Test/testuser.cpp
+++ b/PlotTalk/Test/testuser.cpp
@@ -6,7 +6,6 @@
 #include "testuser.h"
 void TestUser::TestUserDefaultConstructor1()
 {
-
     User user = User();
     QVERIFY(user.username.isEmpty());
     QVERIFY(user.firstName.isEmpty());
@@ -74,7 +73,6 @@ void TestUser::TestsForWatchedList()
     episode3.episodeId=3;
     episode3.seasonId=4;
     episode3.tvShowId=2;
-    int location;
 
     QList<EpisodeIdentifier> episodeGroup;
     episodeGroup.append(episode1);
@@ -126,4 +124,3 @@ void TestUser::TestsForWatchedList()
     user.removeWatchedEpisode(episode3);//cannot remove an episode that isn't in the user
     QCOMPARE(user.hasTheUserWatchedAnything(),false);//the user has watched no shows now
 }
-

--- a/PlotTalk/Test/testuser.cpp
+++ b/PlotTalk/Test/testuser.cpp
@@ -83,30 +83,47 @@ void TestUser::TestsForWatchedList()
 
     User user = User(username, firstName, lastName, email, passwordHash);
     QCOMPARE(user.hasTheUserWatchedAnything(), false);//the user has not watched any shows
-    QCOMPARE(user.addWatchedEpisode(episode1), true);//adding an episode
-    QCOMPARE(user.hasUserWatchedThisEpisode(episode1,location),true);
-    QCOMPARE(location,0);
+
+    user.addWatchedEpisode(episode1);//adding an episode
+    QCOMPARE(user.hasUserWatchedThisEpisode(episode1), true);
     QCOMPARE(user.hasTheUserWatchedAnything(), true);//now the user has watched a show
-    QCOMPARE(user.addWatchedEpisode(episode2), true);//adding a second episode
-    QCOMPARE(user.addWatchedEpisode(episode3), true);//adding a third episode
-    QCOMPARE(user.hasUserWatchedThisEpisode(episode2,location),true);
-    QCOMPARE(location,1);
-    QCOMPARE(user.addWatchedEpisodeList(episodeGroup),false);//one or more episodes already exist
-    QCOMPARE(user.hasUserWatchedThisEpisode(episode3,location),true);
-    QCOMPARE(location,2);
-    QCOMPARE(user.removeWatchedEpisode(episode1), true);//removing the first episode
-    QCOMPARE(user.removeWatchedEpisode(episode1), false);//episode already removed
+
+    user.addWatchedEpisode(episode2);//adding a second episode
+    user.addWatchedEpisode(episode3);//adding a third episode
+
+    QCOMPARE(user.hasUserWatchedThisEpisode(episode2), true);
+
+    user.addWatchedEpisodeList(episodeGroup);//one or more episodes already exist
+
+    QCOMPARE(user.hasUserWatchedThisEpisode(episode3), true);
+
+    user.removeWatchedEpisode(episode1);//removing the first episode
+    user.removeWatchedEpisode(episode1);//episode already removed
+
     QCOMPARE(user.hasTheUserWatchedAnything(), true);//the user has watched shows
-    QCOMPARE(user.addWatchedEpisode(episode2), false);//episode already added
-    QCOMPARE(user.removeWatchedEpisode(episode2), true);//remove second episode
-    QCOMPARE(user.removeWatchedEpisode(episode3), true);//remove third episode
-    QCOMPARE(user.removeWatchedEpisode(episode3), false);//episode already removed
+
+    user.addWatchedEpisode(episode2);//episode already added
+
+    user.removeWatchedEpisode(episode2);//remove second episode
+
+    user.removeWatchedEpisode(episode3);//remove third episode
+    user.removeWatchedEpisode(episode3);//episode already removed
+
+    QCOMPARE(user.hasTheUserWatchedAnything(), false);//the user has watched no shows now
+
+    user.addWatchedEpisodeList(episodeGroup);//adds a list of episode ids to the user
+    user.addWatchedEpisodeList(episodeGroup);//list already addedadded episodes to list
+
+    user.removeWatchedEpisode(episode1);
+    QCOMPARE(user.hasTheUserWatchedAnything(), true); // There should still be episodes left.
+
+    user.removeWatchedEpisode(episode2);
+    QCOMPARE(user.hasTheUserWatchedAnything(), true); // There should still be episodes left.
+
+    user.removeWatchedEpisode(episode3);//successfully remove all the episodes
     QCOMPARE(user.hasTheUserWatchedAnything(),false);//the user has watched no shows now
-    QCOMPARE(user.addWatchedEpisodeList(episodeGroup), true);//adds a list of episode ids to the user
-    QCOMPARE(user.addWatchedEpisodeList(episodeGroup),false);//list already addedadded episodes to list
-    QCOMPARE(user.removeWatchedEpisode(episode1), true);
-    QCOMPARE(user.removeWatchedEpisode(episode2), true);
-    QCOMPARE(user.removeWatchedEpisode(episode3), true);//successfully remove all the episodes
-    QCOMPARE(user.removeWatchedEpisode(episode3), false);//cannot remove an episode that isn't in the user
+
+    user.removeWatchedEpisode(episode3);//cannot remove an episode that isn't in the user
+    QCOMPARE(user.hasTheUserWatchedAnything(),false);//the user has watched no shows now
 }
 


### PR DESCRIPTION
Added addWatchedEpisode and removeWatchedEpisode to:
iconnection interface
jsonconnection
databasemanager

Added tests

Refactored User class a bit to simplify code, and make lookups more efficient. This also changed so that it doesn't create errors to add an episode that is already watched to the list, or remove one that isn't there. I couldn't think of an instance where this should be considered an error. NOTE: We could add asserts for this, if we wanted to expose it in debug builds.

NOTE: the EpisodeIdentifier struct has had some capabilities added to support storing in json, and using a QMap, we may want to consider making it a full blown class.